### PR TITLE
wrong default filename

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -122,7 +122,7 @@ msgstr "Einstellungen öffnen"
 
 #, fuzzy
 #~ msgid "bavarder-%d-%b-%Y"
-#~ msgstr "bavarder-%d-%b-%Y"
+#~ msgstr "imaginer-%d-%b-%Y"
 
 #, fuzzy
 #~ msgid "Image Size"

--- a/po/nl.po
+++ b/po/nl.po
@@ -118,7 +118,7 @@ msgid "Open settings"
 msgstr "Voorkeuren openen"
 
 #~ msgid "bavarder-%d-%b-%Y"
-#~ msgstr "bavarder-%d-%b-%Y"
+#~ msgstr "imaginer-%d-%b-%Y"
 
 #~ msgid "Image Size"
 #~ msgstr "Afbeeldingsgrootte"


### PR DESCRIPTION
I think it's something left from the base project, I have it also in the english version, but I'm not sure how to fix that, searching in the repo doesn't shows other places where it uses this string