### PR TITLE
Fix unhandled error on OpenAI provider

### DIFF
--- a/src/provider/openai.py
+++ b/src/provider/openai.py
@@ -1,6 +1,7 @@
 from .base import ImaginerProvider
 
 import openai
+import requests
 import socket
 
 from gi.repository import Gtk, Adw, GLib


### PR DESCRIPTION
When using OpenAI provider, the app tries to use `requests.get` which is not imported. The app stucks in loading loop, while the error is unhandled in background. Simply importing a library fixes a problem